### PR TITLE
feat: get available name on NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "get-function-name",
+  "name": "get-func-name",
   "description": "Utility for getting a function's name for node and the browser",
   "keywords": [
     "get-function-name",


### PR DESCRIPTION
Hey everyone, so as we were talking on #4 this module's name is already taken.

I changed its name to `get-func-name` in order for us to get this published. If you guys agree please merge this ASAP so we won't lose this namespace too.

Also, after merging this (if everyone agrees) let's change this repo's name.